### PR TITLE
Added Batch Analysis

### DIFF
--- a/pyintelowl/cli/_utils.py
+++ b/pyintelowl/cli/_utils.py
@@ -1,5 +1,6 @@
 import click
 import logging
+import csv
 import json
 from tinynetrc import Netrc
 from rich.emoji import Emoji
@@ -82,6 +83,13 @@ def get_logger(level: str = "INFO"):
 
 def get_json_data(filepath):
     obj = None
-    with open(filepath) as fp:
-        obj = json.load(fp)
+    with open(filepath) as _tmp:
+        line = _tmp.readline()
+        if line[0] in "[{":
+            with open(filepath) as fp:
+                obj = json.load(fp)
+        else:
+            with open(filepath) as fp:
+                reader = csv.DictReader(fp)
+                obj = [dict(row) for row in reader]
     return obj

--- a/pyintelowl/cli/analyse.py
+++ b/pyintelowl/cli/analyse.py
@@ -145,3 +145,25 @@ def file(
         )
     except IntelOwlClientException as e:
         ctx.obj.logger.fatal(str(e))
+
+
+@analyse.command(
+    help="Send multiple analysis requests. Reads file (csv or json) for inputs."
+)
+@click.argument("filepath", type=click.Path(exists=True, resolve_path=True))
+@click.pass_context
+def batch(
+    ctx: ClickContext,
+    filepath: str,
+):
+    rows = get_json_data(filepath)
+    flags = ["run_all", "force_privacy", "private_job", "disable_external_analyzers"]
+    for row in rows:
+        for flag in flags:
+            row[flag] = (row.get(flag, False).lower() == "true") | (
+                row.get(flag, False) == True
+            )
+    try:
+        ctx.obj.send_analysis_batch(rows)
+    except IntelOwlClientException as e:
+        ctx.obj.logger.fatal(str(e))


### PR DESCRIPTION
Supports only JSON files.
Solves Issue #37

![BatchAnalysis](https://user-images.githubusercontent.com/52322531/99901565-5d3b5300-2caf-11eb-84c9-3f70a2bb21a5.png)

Example Json in above screenshot.
```json
[
    {
        "value": "8.8.8.8",
        "type": "observable",
        "run_all": true
    },
    {
        "value": "8.8.4.4",
        "type": "observable",
        "analyzers_list": "ZoomEye,IPInfo"
    },
    {
        "value": "../../tmp/ThinkOutside.jpg",
        "type": "file",
        "run_all": true
    }
]
```

Supports both `JSON` and `CSV` files. No need to specify the type of file.
Flags can be mentioned in the following way.

* Case Insensitive strings of **True** are considered as `True`
* In `json`, default booleans are also considered as `True`
* Everything else is considered as `False`