### PR TITLE
Tags support for requesting new jobs

### DIFF
--- a/pyintelowl/cli/analyse.py
+++ b/pyintelowl/cli/analyse.py
@@ -15,6 +15,13 @@ __analyse_options = [
     """,
     ),
     click.option(
+        "-tl",
+        "--tags-list",
+        type=str,
+        default=(),
+        help="Comma separated list of tag indices for respective job.",
+    ),
+    click.option(
         "-aa",
         "--run-all-available-analyzers",
         "run_all",
@@ -85,6 +92,7 @@ def observable(
     ctx: ClickContext,
     value,
     analyzers_list: str,
+    tags_list: str,
     run_all,
     force_privacy,
     private_job,
@@ -95,6 +103,7 @@ def observable(
 ):
     if not run_all:
         analyzers_list = analyzers_list.split(",")
+    tags_list = list(map(int, tags_list.split(",")))
     if runtime_config:
         runtime_config = get_json_data(runtime_config)
     else:
@@ -104,6 +113,7 @@ def observable(
             value,
             "observable",
             analyzers_list,
+            tags_list,
             run_all,
             force_privacy,
             private_job,
@@ -124,6 +134,7 @@ def file(
     ctx: ClickContext,
     filepath: str,
     analyzers_list: str,
+    tags_list: str,
     run_all,
     force_privacy,
     private_job,
@@ -134,6 +145,7 @@ def file(
 ):
     if not run_all:
         analyzers_list = analyzers_list.split(",")
+    tags_list = list(map(int, tags_list.split(",")))
     if runtime_config:
         runtime_config = get_json_data(runtime_config)
     else:
@@ -143,6 +155,7 @@ def file(
             filepath,
             "file",
             analyzers_list,
+            tags_list,
             run_all,
             force_privacy,
             private_job,

--- a/pyintelowl/pyintelowl.py
+++ b/pyintelowl/pyintelowl.py
@@ -109,6 +109,7 @@ class IntelOwl:
         disable_external_analyzers: bool = False,
         run_all_available_analyzers: bool = False,
         runtime_configuration: Dict = None,
+        tags: List[int] = [],
     ) -> Dict:
         """Send analysis request for a file.\n
         Endpoint: ``/api/send_analysis_request``
@@ -126,6 +127,8 @@ class IntelOwl:
                 Limit view permissions to your groups . Defaults to ``False``.
             disable_external_analyzers (bool, optional):
                 Disable analyzers that use external services. Defaults to ``False``.
+            tags (List[int]):
+                List of tags associated with this job
             run_all_available_analyzers (bool, optional):
                 If True, runs all compatible analyzers. Defaults to ``False``.
             runtime_configuration (Dict, optional):
@@ -145,6 +148,7 @@ class IntelOwl:
                 "is_sample": True,
                 "md5": self.get_md5(binary, type_="binary"),
                 "analyzers_requested": analyzers_requested,
+                "tags_id": tags,
                 "run_all_available_analyzers": run_all_available_analyzers,
                 "force_privacy": force_privacy,
                 "private": private_job,
@@ -168,6 +172,7 @@ class IntelOwl:
         disable_external_analyzers: bool = False,
         run_all_available_analyzers: bool = False,
         runtime_configuration: Dict = None,
+        tags: List[int] = [],
     ) -> Dict:
         """Send analysis request for an observable.\n
         Endpoint: ``/api/send_analysis_request``
@@ -183,6 +188,8 @@ class IntelOwl:
                 Limit view permissions to your groups . Defaults to ``False``.
             disable_external_analyzers (bool, optional):
                 Disable analyzers that use external services. Defaults to ``False``.
+            tags (List[int]):
+                List of tags associated with this job
             run_all_available_analyzers (bool, optional):
                 If True, runs all compatible analyzers. Defaults to ``False``.
             runtime_configuration (Dict, optional):
@@ -202,6 +209,7 @@ class IntelOwl:
                 "is_sample": False,
                 "md5": self.get_md5(observable_name, type_="observable"),
                 "analyzers_requested": analyzers_requested,
+                "tags_id": tags,
                 "run_all_available_analyzers": run_all_available_analyzers,
                 "force_privacy": force_privacy,
                 "private": private_job,
@@ -451,6 +459,7 @@ class IntelOwl:
         obj: str,
         type_: str,
         analyzers_list: List[str],
+        tags_list: List[int],
         run_all: bool,
         force_privacy,
         private_job,
@@ -511,6 +520,7 @@ class IntelOwl:
                 force_privacy=force_privacy,
                 private_job=private_job,
                 disable_external_analyzers=disable_external_analyzers,
+                tags=tags_list,
                 run_all_available_analyzers=run_all,
                 runtime_configuration=runtime_configuration,
             )
@@ -523,6 +533,7 @@ class IntelOwl:
                 force_privacy=force_privacy,
                 private_job=private_job,
                 disable_external_analyzers=disable_external_analyzers,
+                tags=tags_list,
                 run_all_available_analyzers=run_all,
                 runtime_configuration=runtime_configuration,
             )


### PR DESCRIPTION
# Description

Users can specify tags for new jobs, through a string of Comma-Separated Values.

New argument: `-tl` or `--tags-list`

## Fixes
#5 

# Real-world example.
![Tags](https://user-images.githubusercontent.com/52322531/101976804-d855b080-3c40-11eb-8b19-d8daeb3a026e.png)