### PR TITLE
feat: add 'connectors_requested' to analyze methods and cli

### DIFF
--- a/pyintelowl/cli/_jobs_utils.py
+++ b/pyintelowl/cli/_jobs_utils.py
@@ -78,6 +78,7 @@ def _render_job_attributes(data):
         f"{style}Classification:[/] {clsfn}",
         f"{style}Tags:[/] {tags}",
         f"{style}Status:[/] {status}",
+        f"{style}TLP:[/] {data['tlp']}",
     )
     return Panel(r, title="Job attributes")
 

--- a/pyintelowl/cli/analyse.py
+++ b/pyintelowl/cli/analyse.py
@@ -113,13 +113,13 @@ def observable(
             value,
             "observable",
             analyzers_list,
-            connectors_list,
             tags_list,
             run_all,
-            tlp,
             check,
             runtime_config,
             should_poll,
+            tlp,
+            connectors_list,
         )
     except IntelOwlClientException as e:
         ctx.obj.logger.fatal(str(e))
@@ -156,13 +156,13 @@ def file(
             filepath,
             "file",
             analyzers_list,
-            connectors_list,
             tags_list,
             run_all,
-            tlp,
             check,
             runtime_config,
             should_poll,
+            tlp,
+            connectors_list,
         )
     except IntelOwlClientException as e:
         ctx.obj.logger.fatal(str(e))

--- a/pyintelowl/cli/analyse.py
+++ b/pyintelowl/cli/analyse.py
@@ -15,6 +15,16 @@ __analyse_options = [
     """,
     ),
     click.option(
+        "-cl",
+        "--connectors-list",
+        type=str,
+        default="",
+        help="""
+    Comma separated list of specific connector names to invoke.
+    Defaults to all connectors.
+    """,
+    ),
+    click.option(
         "-tl",
         "--tags-list",
         type=str,
@@ -80,6 +90,7 @@ def observable(
     ctx: ClickContext,
     value,
     analyzers_list: str,
+    connectors_list: str,
     tags_list: str,
     run_all,
     tlp,
@@ -87,10 +98,8 @@ def observable(
     runtime_config,
     should_poll: bool,
 ):
-    if not run_all:
-        analyzers_list = analyzers_list.split(",")
-    else:
-        analyzers_list = []
+    analyzers_list = analyzers_list.split(",") if not run_all else []
+    connectors_list = connectors_list.split(",") if connectors_list else []
     if tags_list:
         tags_list = list(map(int, tags_list.split(",")))
     else:
@@ -104,6 +113,7 @@ def observable(
             value,
             "observable",
             analyzers_list,
+            connectors_list,
             tags_list,
             run_all,
             tlp,
@@ -123,6 +133,7 @@ def file(
     ctx: ClickContext,
     filepath: str,
     analyzers_list: str,
+    connectors_list: str,
     tags_list: str,
     run_all,
     tlp,
@@ -130,10 +141,8 @@ def file(
     runtime_config,
     should_poll: bool,
 ):
-    if not run_all:
-        analyzers_list = analyzers_list.split(",")
-    else:
-        analyzers_list = []
+    analyzers_list = analyzers_list.split(",") if not run_all else []
+    connectors_list = connectors_list.split(",") if connectors_list else []
     if tags_list:
         tags_list = list(map(int, tags_list.split(",")))
     else:
@@ -147,6 +156,7 @@ def file(
             filepath,
             "file",
             analyzers_list,
+            connectors_list,
             tags_list,
             run_all,
             tlp,

--- a/pyintelowl/pyintelowl.py
+++ b/pyintelowl/pyintelowl.py
@@ -19,6 +19,9 @@ from typing_extensions import Literal
 from .exceptions import IntelOwlClientException
 
 
+TLPType = Literal["WHITE", "GREEN", "AMBER", "RED"]
+
+
 class IntelOwl:
     logger: logging.Logger
 
@@ -141,7 +144,7 @@ class IntelOwl:
         analyzers_requested: List[str],
         filename: str,
         binary: bytes,
-        tlp: Literal["WHITE", "GREEN", "AMBER", "RED"] = "WHITE",
+        tlp: TLPType = "WHITE",
         run_all_available_analyzers: bool = False,
         runtime_configuration: Dict = None,
         tags: List[int] = None,
@@ -203,7 +206,7 @@ class IntelOwl:
         self,
         analyzers_requested: List[str],
         observable_name: str,
-        tlp: Literal["WHITE", "GREEN", "AMBER", "RED"] = "WHITE",
+        tlp: TLPType = "WHITE",
         run_all_available_analyzers: bool = False,
         runtime_configuration: Dict = None,
         tags: List[int] = None,
@@ -271,8 +274,8 @@ class IntelOwl:
         Args:
             rows (List[Dict]):
                 Each row should be a dictionary with keys,
-                `value`, `type`, `analyzers_list`, `run_all`, `tlp`, `check`,
-                 `connectors_list`.
+                `value`, `type`, `analyzers_list`, `run_all`, `check`,
+                 `runtime_config`, `tlp`, `connectors_list`.
         """
         for obj in rows:
             try:
@@ -290,10 +293,12 @@ class IntelOwl:
                     obj["value"],
                     obj["type"],
                     obj.get("analyzers_list", None),
+                    obj.get("tags_list", []),
                     obj.get("run_all", False),
-                    obj.get("tlp", "WHITE"),
                     obj.get("check", None),
                     runtime_config,
+                    obj.get("should_poll", False),
+                    obj.get("tlp", "WHITE"),
                     connectors_list,
                 )
             except IntelOwlClientException as e:
@@ -488,10 +493,10 @@ class IntelOwl:
         analyzers_list: List[str],
         tags_list: List[int],
         run_all: bool,
-        tlp,
         check,
         runtime_configuration: Dict = None,
         should_poll: bool = False,
+        tlp: TLPType = "WHITE",
         connectors_list: List[str] = [],
     ) -> None:
         """
@@ -515,10 +520,12 @@ class IntelOwl:
             )
             return
         analyzers = analyzers_list if analyzers_list else "all available analyzers"
+        connectors = connectors_list if connectors_list else "all available connectors"
         self.logger.info(
             f"""Requesting analysis..
             {type_}: [blue]{obj}[/]
             analyzers: [i green]{analyzers}[/]
+            connectors: [i green]{connectors}[/]
             """
         )
         # 1st step: ask analysis availability

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -91,10 +91,14 @@ class TestGeneral(BaseTest):
     )
     def test_send_observable_analysis_request(self, mocked_requests):
         analyzers_requested = ["test_1", "test_2"]
+        connectors_requested = ["test_1", "test_2"]
         observable_name = self.domain
         runtime_config = {"test_key": "test_param"}
         result = self.client.send_observable_analysis_request(
-            analyzers_requested, observable_name, runtime_configuration=runtime_config
+            analyzers_requested,
+            observable_name,
+            runtime_configuration=runtime_config,
+            connectors_requested=connectors_requested,
         )
         self.assertIn("status", result)
         self.assertIn("job_id", result)
@@ -105,6 +109,7 @@ class TestGeneral(BaseTest):
     )
     def test_send_observable_analysis_request_failure(self, mocked_requests):
         analyzers_requested = ["test_1", "test_2"]
+        connectors_requested = ["test_1", "test_2"]
         observable_name = self.domain
         runtime_config = {"test_key": "test_param"}
         self.assertRaises(
@@ -113,6 +118,7 @@ class TestGeneral(BaseTest):
             analyzers_requested,
             observable_name,
             runtime_configuration=runtime_config,
+            connectors_requested=connectors_requested,
         )
 
     @mock_connections(
@@ -120,11 +126,16 @@ class TestGeneral(BaseTest):
     )
     def test_send_file_analysis_request(self, mocked_requests):
         analyzers_requested = ["test_1", "test_2"]
+        connectors_requested = ["test_1", "test_2"]
         filename = self.filepath
         binary = get_file_data(self.filepath)
         runtime_config = {"test_key": "test_param"}
         result = self.client.send_file_analysis_request(
-            analyzers_requested, filename, binary, runtime_configuration=runtime_config
+            analyzers_requested,
+            filename,
+            binary,
+            runtime_configuration=runtime_config,
+            connectors_requested=connectors_requested,
         )
         self.assertIn("status", result)
         self.assertIn("job_id", result)
@@ -135,6 +146,7 @@ class TestGeneral(BaseTest):
     )
     def test_send_file_analysis_request_failure(self, mocked_requests):
         analyzers_requested = ["test_1", "test_2"]
+        connectors_requested = ["test_1", "test_2"]
         filename = self.filepath
         binary = get_file_data(self.filepath)
         runtime_config = {"test_key": "test_param"}
@@ -145,6 +157,7 @@ class TestGeneral(BaseTest):
             filename,
             binary,
             runtime_configuration=runtime_config,
+            connectors_requested=connectors_requested,
         )
 
     def test_get_md5_observable(self):


### PR DESCRIPTION
Related to https://github.com/intelowlproject/IntelOwl/issues/629 

Also, a fix was done for `tlp` option (missed in #119) which was causing errors because of positional arguments.

```bash
$ python -m pyintelowl.main analyse observable 8.8.8.8 -al XForceExchange -cl MISP,YETI --check force-new -t WHITE
[02:44:29] INFO     Requesting analysis..                       pyintelowl.py:524
                                observable: 8.8.8.8                              
                                analyzers: ['XForceExchange']                    
                                connectors: ['MISP', 'YETI']                     
                                                                                 
           INFO     New Job running..                           pyintelowl.py:341
                                        ID: 100 | Status:                        
                    accepted.                                                    
                                        Got 0 warnings:                          
                                        None      
```