### PR TITLE
Pages flag added for listing jobs based on page number

### DIFF
--- a/pyintelowl/cli/jobs.py
+++ b/pyintelowl/cli/jobs.py
@@ -45,6 +45,7 @@ def jobs():
 @click.option(
     "-p",
     "--page",
+    type=int,
     help="""
     List jobs of a specific page. Each page contains 10 jobs.
     """,

--- a/pyintelowl/cli/jobs.py
+++ b/pyintelowl/cli/jobs.py
@@ -42,12 +42,22 @@ def jobs():
     show_choices=True,
     help="Only show jobs having a particular status",
 )
+@click.option(
+    "-p",
+    "--page",
+    help="""
+    List jobs of a specific page. Each page contains 10 jobs.
+    """,
+)
 @add_options(json_flag_option)
 @click.pass_context
-def ls(ctx: ClickContext, status: str, as_json: bool):
+def ls(ctx: ClickContext, status: str, as_json: bool, page: int):
     ctx.obj.logger.info("Requesting list of jobs..")
     try:
-        ans = ctx.obj.get_all_jobs()
+        if page:
+            ans = ctx.obj.get_jobs_by_page(page)
+        else:
+            ans = ctx.obj.get_all_jobs()
         results = ans.get("results", [])
         ctx.obj.logger.info(results)
         if status:

--- a/pyintelowl/pyintelowl.py
+++ b/pyintelowl/pyintelowl.py
@@ -581,6 +581,24 @@ class IntelOwl:
         response = self.__make_request("GET", url=url)
         return response.json()
 
+    def get_jobs_by_page(self, page: int) -> List[Dict[str, Any]]:
+        """
+        Fetch list of jobs by page number.\n
+        Endpoint: ``/api/jobs``
+
+        Args:
+            page (int): Page number
+
+        Raises:
+            IntelOwlClientException: on client/HTTP error
+
+        Returns:
+            Dict: Dict with 3 keys: "count", "total_pages", "results"
+        """
+        url = self.instance + f"/api/jobs?page={page}"
+        response = self.__make_request("GET", url=url)
+        return response.json()
+
     def get_tag_by_id(self, tag_id: Union[int, str]) -> Dict[str, str]:
         """Fetch tag info by ID.\n
         Endpoint: ``/api/tag/{tag_id}``

--- a/tests/mocked_requests.py
+++ b/tests/mocked_requests.py
@@ -104,6 +104,14 @@ def mocked_get_all_jobs(*args, **kwargs):
     )
 
 
+def mocked_get_jobs_py_page(*args, **kwargs):
+    return MockResponse(
+        {"count": 1, "total_pages": 1, "results": []},
+        200,
+        "/api/jobs?page=1",
+    )
+
+
 def mocked_delete_job_by_id(*args, **kwargs):
     return MockResponse(
         True,

--- a/tests/mocked_requests.py
+++ b/tests/mocked_requests.py
@@ -104,11 +104,39 @@ def mocked_get_all_jobs(*args, **kwargs):
     )
 
 
-def mocked_get_jobs_py_page(*args, **kwargs):
+def mocked_get_jobs_by_page(*args, **kwargs):
     return MockResponse(
-        {"count": 1, "total_pages": 1, "results": []},
+        {
+            "count": 1,
+            "total_pages": 1,
+            "results": [
+                {
+                    "id": 1057,
+                    "user": {"username": "pranjal"},
+                    "tags": [],
+                    "pivots_to_execute": [],
+                    "analyzers_to_execute": ["UltraDNSAnalyzer"],
+                    "connectors_to_execute": [],
+                    "visualizers_to_execute": [],
+                    "playbook_to_execute": [],
+                    "is_sample": False,
+                    "md5": "",
+                    "observable_name": "",
+                    "observable_classification": "",
+                    "file_name": "",
+                    "file_mimetype": "",
+                    "status": "",
+                    "received_request_time": "",
+                    "finished_analysis_time": "",
+                    "process_time": 3.44,
+                    "tlp": "RED",
+                    "investigation": [],
+                    "playbook_requested": [],
+                }
+            ],
+        },
         200,
-        "/api/jobs?page=1",
+        "/api/jobs",
     )
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,6 +6,7 @@ from tests.mocked_requests import (
     mocked_download_job_sample,
     mocked_get_all_jobs,
     mocked_get_job_by_id,
+    mocked_get_jobs_py_page,
     mocked_kill_analyzer,
     mocked_kill_connector,
     mocked_kill_job,
@@ -25,6 +26,19 @@ class TestJobs(BaseTest):
     @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
     def test_get_all_jobs_failure(self, mock_requests):
         self.assertRaises(IntelOwlClientException, self.client.get_all_jobs)
+
+    @mock_connections(
+        patch("requests.Session.get", side_effect=mocked_get_jobs_py_page)
+    )
+    def test_get_jobs_by_page_success(self, mock_requests):
+        page = 1
+        jobs = self.client.get_jobs_by_page(page)
+        self.assertIsInstance(jobs, dict)
+
+    @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
+    def test_get_jobs_by_page_failure(self, mock_requests):
+        page = 1
+        self.assertRaises(IntelOwlClientException, self.client.get_jobs_by_page, page)
 
     @mock_connections(patch("requests.Session.get", side_effect=mocked_get_job_by_id))
     def test_get_job_by_id_valid(self, mock_requests):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -83,6 +83,14 @@ class TestJobs(BaseTest):
             IntelOwlClientException, self.client.kill_running_job, self.job_id
         )
 
+    @mock_connections(
+        patch("requests.Session.get", side_effect=mocked_download_job_sample)
+    )
+    def test_download_job_sample(self, mocked_requests):
+        file_data = get_file_data(self.filepath)
+        downloaded = self.client.download_sample(self.job_id)
+        self.assertEqual(downloaded, file_data)
+
     @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
     def test_download_job_sample_failure(self, mocked_requests):
         self.assertRaises(

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -6,7 +6,7 @@ from tests.mocked_requests import (
     mocked_download_job_sample,
     mocked_get_all_jobs,
     mocked_get_job_by_id,
-    mocked_get_jobs_py_page,
+    mocked_get_jobs_by_page,
     mocked_kill_analyzer,
     mocked_kill_connector,
     mocked_kill_job,
@@ -28,12 +28,17 @@ class TestJobs(BaseTest):
         self.assertRaises(IntelOwlClientException, self.client.get_all_jobs)
 
     @mock_connections(
-        patch("requests.Session.get", side_effect=mocked_get_jobs_py_page)
+        patch("requests.Session.get", side_effect=mocked_get_jobs_by_page)
     )
     def test_get_jobs_by_page_success(self, mock_requests):
         page = 1
         jobs = self.client.get_jobs_by_page(page)
         self.assertIsInstance(jobs, dict)
+        self.assertIsInstance(
+            jobs.get("results"), list, "Results key should contain a list"
+        )
+        for job in jobs.get("results"):
+            self.assertIn("id", job, "Job missing 'id' field")
 
     @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
     def test_get_jobs_by_page_failure(self, mock_requests):
@@ -77,14 +82,6 @@ class TestJobs(BaseTest):
         self.assertRaises(
             IntelOwlClientException, self.client.kill_running_job, self.job_id
         )
-
-    @mock_connections(
-        patch("requests.Session.get", side_effect=mocked_download_job_sample)
-    )
-    def test_download_job_sample(self, mocked_requests):
-        file_data = get_file_data(self.filepath)
-        downloaded = self.client.download_sample(self.job_id)
-        self.assertEqual(downloaded, file_data)
 
     @mock_connections(patch("requests.Session.get", side_effect=mocked_raise_exception))
     def test_download_job_sample_failure(self, mocked_requests):


### PR DESCRIPTION
# Description
I have added a new function `get_jobs_by_page` that returns a jobs list based on the page number. 
Please include a summary of the change.

## Related issues
Closes #264 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [ x] The pull request is for the branch develop
- [ ] I have added tests in the [Tests](https://github.com/intelowlproject/pyintelowl/tree/master/tests) folder. 
- [ ] The tests gave 0 errors.
- [ x] `Black` gave 0 errors.
- [ x] `Flake` gave 0 errors.
- [ ] I squashed the commits into a single one. (optional, they will be squashed anyway by the maintainer)
  
### please follow these rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review

# Real World Example

Please delete if the PR is for bug fixing.
Otherwise, please provide the resulting raw JSON of a finished analysis (and, if you like, a screenshot of the results). This is to allow the maintainers to understand how the analyzer works.
